### PR TITLE
Added composer.json support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 composer.lock
-vendor
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "roots/bedrock-autoloader",
+  "license": "MIT",
+  "description": "An autoloader that enables standard plugins to be required just like must-use plugins",
+  "authors": [
+    {
+      "name": "Scott Walkinshaw",
+      "email": "scott.walkinshaw@gmail.com",
+      "homepage": "https://github.com/swalkinshaw"
+    }
+  ],
+  "keywords": [
+    "autoloader", "bedrock", "mu-plugin", "must-user", "plugin", "wordpress"
+  ],
+  "support": {
+    "forum": "https://discourse.roots.io/"
+  },
+  "require": {
+    "php": ">=7.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "Roots\\Bedrock\\": "src/"
+    }
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
       "name": "Scott Walkinshaw",
       "email": "scott.walkinshaw@gmail.com",
       "homepage": "https://github.com/swalkinshaw"
+    },
+    {
+      "name": "Austin Pray",
+      "email": "austin@austinpray.com",
+      "homepage": "https://github.com/austinpray"
     }
   ],
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,11 @@
   "description": "An autoloader that enables standard plugins to be required just like must-use plugins",
   "authors": [
     {
+      "name": "Nick Fox",
+      "email": "nick@foxaii.com",
+      "homepage": "https://github.com/foxaii"
+    },
+    {
       "name": "Scott Walkinshaw",
       "email": "scott.walkinshaw@gmail.com",
       "homepage": "https://github.com/swalkinshaw"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "keywords": [
-    "autoloader", "bedrock", "mu-plugin", "must-user", "plugin", "wordpress"
+    "autoloader", "bedrock", "mu-plugin", "must-use", "plugin", "wordpress"
   ],
   "support": {
     "forum": "https://discourse.roots.io/"


### PR DESCRIPTION
This pull request adds Composer support to the autoloader. Couple of questions before this pull request can be merged:

1. Should it be named `roots/bedrock-autoloader` or `roots/autoloader`?
2. Should it live on as a `mu-plugin` or as a "normal" Composer package (discussed in #5)?
3. Whom should we specify as authors?

Closes #1