### PR TITLE
Remove code outside of class definition

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -11,10 +11,6 @@
 
 namespace Roots\Bedrock;
 
-if (!is_blog_installed()) {
-    return;
-}
-
 /**
  * Class Autoloader
  * @package Roots\Bedrock
@@ -195,5 +191,3 @@ class Autoloader
         return $this->count;
     }
 }
-
-new Autoloader();


### PR DESCRIPTION
This PR removes code that doesn't belong in the main `Autoloader` class file. It should be (and is) used in the mu-plugin that uses it.

https://github.com/roots/bedrock/blob/21bc13c163bed1b24785f03772b55f39001383fa/web/app/mu-plugins/bedrock-autoloader.php

See https://github.com/roots/bedrock/pull/519