### PR TITLE
Exclude non-essential files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+/tests export-ignore
+/.github export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml export-ignore
+/README.md export-ignore


### PR DESCRIPTION
This will remove the files listed in the `.gitattributes` file when it the package is installed for use in production. 

[Read more about excluding non-essential files on Reddit.](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production)