### PR TITLE
✨ Add autoloaded plugins to `active_plugins` option

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -194,6 +194,12 @@ class Autoloader
      */
     public function addAutoPlugins(array $plugins): array
     {
+        // If on plugin overview screen (wp-admin/plugins.php), return early.
+        // Otherwise WP will nag about missing plugins.
+        global $pagenow;
+        if ($pagenow === 'plugins.php') {
+            return $plugins;
+        }
         $cache = get_site_option('bedrock_autoloader');
         if ( ! $cache
             || ! is_array($cache['plugins'])

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -46,6 +46,9 @@ class Autoloader
 
         if (is_admin()) {
             add_filter('show_advanced_plugins', [$this, 'showInAdmin'], 0, 2);
+
+            // Add filter to add autoPlugins to the array of active plugins
+            add_filter('option_active_plugins', [$this, 'addAutoPlugins']);
         }
 
         $this->loadPlugins();
@@ -180,5 +183,24 @@ class Autoloader
         }
 
         return $this->count;
+    }
+
+    /**
+     * Add the autoloaded plugins to the array of active plugins.
+     *
+     * @param array $plugins Array of active plugins.
+     *
+     * @return array
+     */
+    public function addAutoPlugins(array $plugins): array
+    {
+        $cache = get_site_option('bedrock_autoloader');
+        if ( ! $cache
+            || ! is_array($cache['plugins'])
+        ) {
+            return $plugins;
+        }
+
+        return array_merge($plugins, array_keys($cache['plugins']));
     }
 }


### PR DESCRIPTION
Currently autoloaded `mu-plugins` won't be listed in the `active_plugins` option. Thus, the function `is_plugin_active()` won't return true for these plugins.

This might / will break some plugins, which rely on this - i.e. the current ACF Pro version 6.2.3, which won't show the subpage for updates / license management.

This PR hooks into the `active_plugins` option and adds all (cached) plugins to the return.

### Test this PR

```bash
# Require PR / fork
composer config repositories.bedrock-autoloader vcs https://github.com/zirkeldesign/bedrock-autoloader
composer require roots/bedrock-autoloader:dev-patch-active-plugins
```