### PR TITLE
Add a filter to allow developers to block certain plugins from being loaded

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -60,9 +60,10 @@ class Autoloader
         $this->validatePlugins();
         $this->countPlugins();
 
+        $pluginEntryPoints = apply_filters('bedrock_autoloader_load_plugins', array_keys($this->cache['plugins']), $this->cache['plugins']);
         array_map(static function () {
             include_once WPMU_PLUGIN_DIR . '/' . func_get_args()[0];
-        }, array_keys($this->cache['plugins']));
+        }, $pluginEntryPoints);
 
         add_action('plugins_loaded', [$this, 'pluginHooks'], -9999);
     }


### PR DESCRIPTION
The filter can be used like this:

```php
add_filter('bedrock_autoloader_load_plugins', function ($plugins) {
    return array_filter($plugins, function ($name) {
        return !str_starts_with($name, 'my-plugin-name/');
    });
});
new Autoloader();
```

This pull request solves https://github.com/roots/bedrock-autoloader/issues/34