### PR TITLE
Fix plugin discovery, counting, and activation timing

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -66,7 +66,7 @@ class Autoloader
             include_once WPMU_PLUGIN_DIR . '/' . $plugin;
         }, $this->loadedPluginEntryPoints);
 
-        add_action('plugins_loaded', [$this, 'pluginHooks'], -9999);
+        add_action('init', [$this, 'pluginHooks'], 0);
     }
 
     /**

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -104,7 +104,7 @@ class Autoloader
     {
         $cache = get_site_option('bedrock_autoloader');
 
-        if ($cache === false || (isset($cache['plugins'], $cache['count']) && count($cache['plugins']) !== $cache['count'])) {
+        if ($cache === false || (isset($cache['plugins'], $cache['count']) && $this->countPluginDirs($cache['plugins']) !== $cache['count'])) {
             $this->updateCache();
             return;
         }
@@ -164,7 +164,8 @@ class Autoloader
             ),
             $plugins
         );
-        $this->cache       = ['plugins' => $plugins, 'count' => $this->countPlugins()];
+        $this->count       = $this->countPluginDirs($plugins);
+        $this->cache       = ['plugins' => $plugins, 'count' => $this->count];
 
         update_site_option('bedrock_autoloader', $this->cache);
         update_site_option('bedrock_autoloader_new_plugins', $newPlugins);
@@ -203,12 +204,23 @@ class Autoloader
     }
 
     /**
-     * Count the number of autoloaded plugins.
+     * Count unique top-level plugin directories from a plugin map.
      *
-     * Count our plugins (but only once) by counting the top level folders in the
-     * mu-plugins dir. If it's more or less than last time, update the cache.
-     *
-     * @return int Number of autoloaded plugins.
+     * @param array $plugins Plugin data keyed by relative path
+     * @return int Number of unique plugin directories
+     */
+    private function countPluginDirs(array $plugins)
+    {
+        $dirs = [];
+        foreach (array_keys($plugins) as $entryPoint) {
+            $dirs[dirname($entryPoint)] = true;
+        }
+        return count($dirs);
+    }
+
+    /**
+     * Count autoloaded plugins on the filesystem and trigger a cache
+     * update if the count has changed since last check.
      */
     private function countPlugins()
     {
@@ -216,7 +228,9 @@ class Autoloader
             return $this->count;
         }
 
-        $count = count(glob(WPMU_PLUGIN_DIR . '/*/', GLOB_ONLYDIR | GLOB_NOSORT));
+        $discovered = $this->discoverPlugins();
+        $muPlugins = get_mu_plugins();
+        $count = $this->countPluginDirs(array_diff_key($discovered, $muPlugins));
 
         if (!isset($this->cache['count']) || $count !== $this->cache['count']) {
             $this->count = $count;

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -113,15 +113,47 @@ class Autoloader
     }
 
     /**
+     * Discover autoloadable plugins in the mu-plugins directory.
+     *
+     * Uses get_plugins() when WP_PLUGIN_DIR exists, otherwise falls back
+     * to scanning WPMU_PLUGIN_DIR subdirectories for valid plugin headers.
+     *
+     * @return array Plugin data keyed by relative path (e.g. 'plugin-dir/plugin-file.php')
+     */
+    private function discoverPlugins()
+    {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+        if (is_dir(WP_PLUGIN_DIR)) {
+            return get_plugins($this->relativePath);
+        }
+
+        $plugins = [];
+
+        foreach ((array) glob(WPMU_PLUGIN_DIR . '/*/*.php', GLOB_NOSORT) as $file) {
+            $data = get_plugin_data($file, false, false);
+
+            if (empty($data['Name'])) {
+                continue;
+            }
+
+            $relativePath = basename(dirname($file)) . '/' . basename($file);
+            $plugins[$relativePath] = $data;
+        }
+
+        ksort($plugins);
+
+        return $plugins;
+    }
+
+    /**
      * Get the plugins and mu-plugins from the mu-plugin path and remove duplicates.
      * Check cache against current plugins for newly activated plugins.
      * After that, we can update the cache.
      */
     private function updateCache()
     {
-        require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-        $this->autoPlugins = get_plugins($this->relativePath);
+        $this->autoPlugins = $this->discoverPlugins();
         $this->muPlugins   = get_mu_plugins();
         $plugins           = array_diff_key($this->autoPlugins, $this->muPlugins);
         $rebuild           = !isset($this->cache['plugins']);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 
 define('WPMU_PLUGIN_DIR', __DIR__ . '/fixtures/mu-plugins');
+define('WP_PLUGIN_DIR', __DIR__ . '/fixtures/plugins');
 define('ABSPATH', __DIR__ . '/fixtures/wp/');
 
 // Can't activate strict mode due to untestable code

--- a/tests/fixtures/mu-plugins/not-a-plugin/readme.txt
+++ b/tests/fixtures/mu-plugins/not-a-plugin/readme.txt
@@ -1,0 +1,1 @@
+This directory has no valid plugin header file.

--- a/tests/unit/AutoloaderTest.php
+++ b/tests/unit/AutoloaderTest.php
@@ -238,7 +238,11 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         $this->assertNotContains('../../etc/passwd', $loaded);
     }
 
-    public function testFallbackDiscoveryWhenPluginsDirMissing()
+    /**
+     * Run a callback with WP_PLUGIN_DIR temporarily removed,
+     * exercising the fallback discovery path.
+     */
+    private function withFallbackDiscovery(callable $callback): void
     {
         $pluginsDir = WP_PLUGIN_DIR;
         $tempDir = $pluginsDir . '_disabled';
@@ -260,6 +264,15 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
             $a = $reflect->newInstanceWithoutConstructor();
             $this->setProperty($a, 'relativePath', '/../' . basename(WPMU_PLUGIN_DIR));
 
+            $callback($a, $reflect);
+        } finally {
+            rename($tempDir, $pluginsDir);
+        }
+    }
+
+    public function testFallbackDiscoveryWhenPluginsDirMissing()
+    {
+        $this->withFallbackDiscovery(function (Autoloader $a, \ReflectionClass $reflect) {
             $method = $reflect->getMethod('discoverPlugins');
             $method->setAccessible(true);
             $plugins = $method->invoke($a);
@@ -268,12 +281,26 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
             $this->assertArrayHasKey('10-fake/10-fake.php', $plugins);
             $this->assertArrayHasKey('20-fake/20-fake.php', $plugins);
 
-            // Verify deterministic ordering
             $keys = array_keys($plugins);
             $this->assertEquals('10-fake/10-fake.php', $keys[0]);
             $this->assertEquals('20-fake/20-fake.php', $keys[1]);
-        } finally {
-            rename($tempDir, $pluginsDir);
-        }
+        });
+    }
+
+    public function testCountExcludesNonPluginDirectories()
+    {
+        $this->withFallbackDiscovery(function (Autoloader $a, \ReflectionClass $reflect) {
+            $discover = $reflect->getMethod('discoverPlugins');
+            $discover->setAccessible(true);
+            $plugins = $discover->invoke($a);
+
+            $countDirs = $reflect->getMethod('countPluginDirs');
+            $countDirs->setAccessible(true);
+            $count = $countDirs->invoke($a, $plugins);
+
+            // fixtures/mu-plugins has 3 subdirs (10-fake, 20-fake, not-a-plugin)
+            // but only 2 are valid plugins — count should be 2
+            $this->assertEquals(2, $count);
+        });
     }
 }

--- a/tests/unit/AutoloaderTest.php
+++ b/tests/unit/AutoloaderTest.php
@@ -237,4 +237,43 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         $this->assertContains('20-fake/20-fake.php', $loaded);
         $this->assertNotContains('../../etc/passwd', $loaded);
     }
+
+    public function testFallbackDiscoveryWhenPluginsDirMissing()
+    {
+        $pluginsDir = WP_PLUGIN_DIR;
+        $tempDir = $pluginsDir . '_disabled';
+        rename($pluginsDir, $tempDir);
+
+        try {
+            \WP_Mock::userFunction('get_plugin_data', [
+                'return' => function ($file) {
+                    $relativePath = basename(dirname($file)) . '/' . basename($file);
+                    $map = [
+                        '10-fake/10-fake.php' => ['Name' => 'UwU', 'Version' => '1.0.0'],
+                        '20-fake/20-fake.php' => ['Name' => '0w0', 'Version' => '1.0.0'],
+                    ];
+                    return $map[$relativePath] ?? ['Name' => ''];
+                },
+            ]);
+
+            $reflect = new \ReflectionClass(Autoloader::class);
+            $a = $reflect->newInstanceWithoutConstructor();
+            $this->setProperty($a, 'relativePath', '/../' . basename(WPMU_PLUGIN_DIR));
+
+            $method = $reflect->getMethod('discoverPlugins');
+            $method->setAccessible(true);
+            $plugins = $method->invoke($a);
+
+            $this->assertCount(2, $plugins);
+            $this->assertArrayHasKey('10-fake/10-fake.php', $plugins);
+            $this->assertArrayHasKey('20-fake/20-fake.php', $plugins);
+
+            // Verify deterministic ordering
+            $keys = array_keys($plugins);
+            $this->assertEquals('10-fake/10-fake.php', $keys[0]);
+            $this->assertEquals('20-fake/20-fake.php', $keys[1]);
+        } finally {
+            rename($tempDir, $pluginsDir);
+        }
+    }
 }

--- a/tests/unit/AutoloaderTest.php
+++ b/tests/unit/AutoloaderTest.php
@@ -61,6 +61,7 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         \WP_Mock::userFunction('update_site_option', ['return' => true]);
         \WP_Mock::userFunction('add_action', ['return' => true]);
         \WP_Mock::userFunction('add_filter', ['return' => true]);
+        \WP_Mock::userFunction('get_plugin_data', ['return' => ['Name' => '']]);
     }
 
     public function testLoadPlugins()


### PR DESCRIPTION
## Summary

- **Fix autoloader failure when plugins directory does not exist (#30)** — Add `discoverPlugins()` as a single canonical discovery path. Uses `get_plugins()` when `WP_PLUGIN_DIR` exists, falls back to scanning `WPMU_PLUGIN_DIR` with `get_plugin_data()` when it doesn't.
- **Fix countPlugins counting non-plugin directories (#26)** — Replace glob-based directory counting with `countPluginDirs()`, which derives count from unique top-level directories of discovered plugin entry points. Non-plugin directories no longer inflate the count or trigger repeated cache rebuild checks.
- **Move synthetic activation hooks from plugins_loaded to init (#23)** — Fire `activate_` hooks on `init` (priority 0) instead of `plugins_loaded` so that plugins which assume fuller WordPress context during activation (e.g. rewrite rules, post types, taxonomies) don't fatal on first load.

## Test plan

- [x] All plugins load correctly with `WP_PLUGIN_DIR` present
- [x] Fallback discovery works when `WP_PLUGIN_DIR` is missing
- [x] Non-plugin directories in mu-plugins don't inflate count or trigger cache rebuilds
- [x] Activation timing changed to `init` in code path; existing `pluginHooks` behavior remains covered
- [x] Filtered plugin exclusion, deferred activation, and pruning still work

Closes #23
Closes #26
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)