### PR TITLE
Fix autoloader when plugins directory is a symlink

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -125,7 +125,10 @@ class Autoloader
         require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
         if (is_dir(WP_PLUGIN_DIR)) {
-            return get_plugins($this->relativePath);
+            $plugins = get_plugins($this->relativePath);
+            if (!empty($plugins)) {
+                return $plugins;
+            }
         }
 
         $plugins = [];


### PR DESCRIPTION
## Summary

- When `WP_PLUGIN_DIR` is a symlink pointing to a different location on the filesystem, `get_plugins('/../mu-plugins')` fails because the relative path traversal resolves through the symlink target's real parent — which may not contain `mu-plugins`.
- Fix: if `get_plugins()` returns empty, fall through to the direct `WPMU_PLUGIN_DIR` scanner (added in #38); this avoids brittle relative-path resolution in symlinked `WP_PLUGIN_DIR` setups.
- Root cause is [WordPress core ticket #34358](https://core.trac.wordpress.org/ticket/34358).

## Test plan

- [x] Reproduced locally: symlinked `plugins/` to a sibling directory outside `content/`, confirmed mu-plugins failed to load
- [x] Verified fix: fallback scanner discovers mu-plugins directly via `WPMU_PLUGIN_DIR`
- [x] Normal (non-symlinked) setups continue to use `get_plugins()` path
- [x] All unit tests pass

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)