### PR TITLE
Require PHP 8.2+ and update CI and dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,3 @@
-  
 name: Tests
 
 on: [push, pull_request]
@@ -9,12 +8,12 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        php: ['8.2', '8.3', '8.4', '8.5']
 
     name: PHP ${{ matrix.php }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "forum": "https://discourse.roots.io/"
   },
   "require": {
-    "php": ">=7.1"
+    "php": ">=8.2"
   },
   "autoload": {
     "psr-4": {
@@ -39,7 +39,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
-    "10up/wp_mock": "^0.4.2"
+    "phpunit/phpunit": "^9.6",
+    "10up/wp_mock": "^1.1"
   }
 }


### PR DESCRIPTION
## Summary

- Bump minimum PHP version from 7.1 to 8.2
- Update CI test matrix to PHP 8.2, 8.3, 8.4, 8.5
- Update `actions/checkout` from v2 to v6
- Update `phpunit/phpunit` to `^9.6` and `10up/wp_mock` to `^1.1`

## Test plan

- [x] All 9 tests pass on PHP 8.2 with updated dependencies
- [x] `composer validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)