### PR TITLE
Change namespace to `Roots\Bedrock\Autoloader`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Roots\\Bedrock\\": "src/"
+      "Roots\\Bedrock\\Autoloader\\": "src/"
     }
   },
   "require-dev": {

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Roots\Bedrock;
+namespace Roots\Bedrock\Autoloader;
 
 /**
  * Class Autoloader

--- a/tests/unit/AutoloaderTest.php
+++ b/tests/unit/AutoloaderTest.php
@@ -2,7 +2,7 @@
 
 namespace unit;
 
-use Roots\Bedrock\Autoloader;
+use Roots\Bedrock\Autoloader\Autoloader;
 
 class AutoloaderTest extends \WP_Mock\Tools\TestCase
 {


### PR DESCRIPTION
## Summary

- Changes namespace from `Roots\Bedrock` to `Roots\Bedrock\Autoloader`
- Updates PSR-4 autoload mapping in `composer.json`
- Updates test imports

Closes #7

## Upgrade guide

Update `mu-plugins/bedrock-autoloader.php`:

```php
<?php

if (is_blog_installed() && class_exists(\Roots\Bedrock\Autoloader\Autoloader::class)) {
    new \Roots\Bedrock\Autoloader\Autoloader();
}
```

Bedrock will be updated with this change after v2 is tagged.

## Test plan

- [x] Unit tests pass
- [x] Tested locally with Radicle — autoloader discovers and loads mu-plugins correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)