### PR TITLE
Make constructor side-effect-free and inject mu-plugin path

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -11,9 +11,6 @@ namespace Roots\Bedrock\Autoloader;
  */
 class Autoloader
 {
-    /** @var static Singleton instance */
-    private static $instance;
-
     /** @var array Store Autoloader cache and site option */
     private $cache;
 
@@ -26,24 +23,26 @@ class Autoloader
     /** @var int Number of plugins */
     private $count;
 
-    /** @var string Relative path to the mu-plugins dir */
-    private $relativePath;
-
     /** @var array Entrypoints of all loaded plugins */
     private $loadedPluginEntryPoints;
 
+    /** @var bool Whether boot() has already run */
+    private $booted = false;
+
+    public function __construct(
+        private string $muPluginDir,
+    ) {}
+
     /**
-     * Create singleton, populate vars, and set WordPress hooks
+     * Register hooks and load plugins. Idempotent.
      */
-    public function __construct()
+    public function boot(): void
     {
-        if (isset(self::$instance)) {
+        if ($this->booted) {
             return;
         }
 
-        self::$instance = $this;
-
-        $this->relativePath = '/../'.basename(WPMU_PLUGIN_DIR);
+        $this->booted = true;
 
         if (is_admin()) {
             add_filter('show_advanced_plugins', [$this, 'showInAdmin'], 0, 2);
@@ -63,8 +62,8 @@ class Autoloader
 
         $filtered = apply_filters('bedrock_autoloader_load_plugins', array_keys($this->cache['plugins']), $this->cache['plugins']);
         $this->loadedPluginEntryPoints = array_values(array_intersect((array) $filtered, array_keys($this->cache['plugins'])));
-        array_map(static function ($plugin) {
-            include_once WPMU_PLUGIN_DIR.'/'.$plugin;
+        array_map(function ($plugin) {
+            include_once $this->muPluginDir.'/'.$plugin;
         }, $this->loadedPluginEntryPoints);
 
         add_action('init', [$this, 'pluginHooks'], 0);
@@ -119,8 +118,7 @@ class Autoloader
     /**
      * Discover autoloadable plugins in the mu-plugins directory.
      *
-     * Uses get_plugins() when WP_PLUGIN_DIR exists, otherwise falls back
-     * to scanning WPMU_PLUGIN_DIR subdirectories for valid plugin headers.
+     * Scans mu-plugin subdirectories for PHP files with valid plugin headers.
      *
      * @return array Plugin data keyed by relative path (e.g. 'plugin-dir/plugin-file.php')
      */
@@ -128,16 +126,9 @@ class Autoloader
     {
         require_once ABSPATH.'wp-admin/includes/plugin.php';
 
-        if (is_dir(WP_PLUGIN_DIR)) {
-            $plugins = get_plugins($this->relativePath);
-            if (! empty($plugins)) {
-                return $plugins;
-            }
-        }
-
         $plugins = [];
 
-        foreach ((array) glob(WPMU_PLUGIN_DIR.'/*/*.php', GLOB_NOSORT) as $file) {
+        foreach ((array) glob($this->muPluginDir.'/*/*.php', GLOB_NOSORT) as $file) {
             $data = get_plugin_data($file, false, false);
 
             if (empty($data['Name'])) {
@@ -203,7 +194,7 @@ class Autoloader
     private function validatePlugins()
     {
         foreach ($this->cache['plugins'] as $plugin_file => $plugin_info) {
-            if (! file_exists(WPMU_PLUGIN_DIR.'/'.$plugin_file)) {
+            if (! file_exists($this->muPluginDir.'/'.$plugin_file)) {
                 $this->updateCache();
                 break;
             }

--- a/tests/unit/AutoloaderTest.php
+++ b/tests/unit/AutoloaderTest.php
@@ -14,11 +14,6 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
     public function setUp(): void
     {
         \WP_Mock::setUp();
-
-        $reflect = new \ReflectionClass(Autoloader::class);
-        $instance = $reflect->getProperty('instance');
-        $instance->setAccessible(true);
-        $instance->setValue(null, null);
     }
 
     public function tearDown(): void
@@ -43,13 +38,26 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         $prop->setValue($a, $value);
     }
 
+    private function makeAutoloader(string $muPluginDir = WPMU_PLUGIN_DIR): Autoloader
+    {
+        return new Autoloader($muPluginDir);
+    }
+
+    private function mockPluginData(): void
+    {
+        \WP_Mock::userFunction('get_plugin_data', [
+            'return' => function ($file) {
+                $relativePath = basename(dirname($file)).'/'.basename($file);
+
+                return self::$plugins[$relativePath] ?? ['Name' => ''];
+            },
+        ]);
+    }
+
     private function mockBaseWpFunctions(): void
     {
         \WP_Mock::userFunction('is_admin', ['return' => false]);
-        \WP_Mock::userFunction('get_plugins', [
-            'args' => '/../mu-plugins',
-            'return' => self::$plugins,
-        ]);
+        $this->mockPluginData();
         \WP_Mock::userFunction('get_mu_plugins', ['return' => []]);
         \WP_Mock::userFunction('get_site_option', [
             'args' => ['bedrock_autoloader'],
@@ -62,14 +70,41 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         \WP_Mock::userFunction('update_site_option', ['return' => true]);
         \WP_Mock::userFunction('add_action', ['return' => true]);
         \WP_Mock::userFunction('add_filter', ['return' => true]);
-        \WP_Mock::userFunction('get_plugin_data', ['return' => ['Name' => '']]);
+    }
+
+    public function test_constructor_has_no_side_effects()
+    {
+        $a = $this->makeAutoloader();
+
+        $this->assertNull($this->getProperty($a, 'cache'));
+        $this->assertNull($this->getProperty($a, 'autoPlugins'));
+        $this->assertNull($this->getProperty($a, 'loadedPluginEntryPoints'));
+        $this->assertFalse($this->getProperty($a, 'booted'));
+    }
+
+    public function test_boot_is_idempotent()
+    {
+        $this->mockBaseWpFunctions();
+
+        $a = $this->makeAutoloader();
+        $a->boot();
+
+        $cacheAfterFirst = $this->getProperty($a, 'cache');
+
+        // Second boot should be a no-op — loadPlugins won't run again
+        $a->boot();
+
+        $cacheAfterSecond = $this->getProperty($a, 'cache');
+        $this->assertSame($cacheAfterFirst, $cacheAfterSecond);
+        $this->assertTrue($this->getProperty($a, 'booted'));
     }
 
     public function test_load_plugins()
     {
         $this->mockBaseWpFunctions();
 
-        $a = new Autoloader;
+        $a = $this->makeAutoloader();
+        $a->boot();
 
         $cache = $this->getProperty($a, 'cache');
         $this->assertCount(2, $cache['plugins']);
@@ -89,7 +124,8 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
             ->with(array_keys(self::$plugins), self::$plugins)
             ->reply(['20-fake/20-fake.php']);
 
-        $a = new Autoloader;
+        $a = $this->makeAutoloader();
+        $a->boot();
 
         $loaded = $this->getProperty($a, 'loadedPluginEntryPoints');
         $this->assertCount(1, $loaded);
@@ -99,8 +135,7 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
 
     public function test_filtered_plugin_activation_is_deferred()
     {
-        $reflect = new \ReflectionClass(Autoloader::class);
-        $a = $reflect->newInstanceWithoutConstructor();
+        $a = $this->makeAutoloader();
 
         // 10-fake was filtered out on this request
         $this->setProperty($a, 'loadedPluginEntryPoints', ['20-fake/20-fake.php']);
@@ -135,8 +170,7 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
 
     public function test_unfiltered_plugin_gets_activate_hook()
     {
-        $reflect = new \ReflectionClass(Autoloader::class);
-        $a = $reflect->newInstanceWithoutConstructor();
+        $a = $this->makeAutoloader();
 
         // 10-fake is now loaded (was previously filtered out)
         $this->setProperty($a, 'loadedPluginEntryPoints', [
@@ -168,12 +202,7 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
     public function test_removed_plugin_is_pruned_from_pending()
     {
         \WP_Mock::userFunction('is_admin', ['return' => false]);
-        \WP_Mock::userFunction('get_plugins', [
-            'args' => '/../mu-plugins',
-            'return' => [
-                '10-fake/10-fake.php' => self::$plugins['10-fake/10-fake.php'],
-            ],
-        ]);
+        $this->mockPluginData();
         \WP_Mock::userFunction('get_mu_plugins', ['return' => []]);
         \WP_Mock::userFunction('get_site_option', [
             'args' => ['bedrock_autoloader'],
@@ -188,10 +217,8 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
             ],
         ]);
 
-        // Pruned new_plugins should only contain 10-fake
-        $expectedNewPlugins = [
-            '10-fake/10-fake.php' => self::$plugins['10-fake/10-fake.php'],
-        ];
+        // Pruned new_plugins should contain both discovered plugins (stale one removed)
+        $expectedNewPlugins = self::$plugins;
         \WP_Mock::userFunction('update_site_option', [
             'args' => ['bedrock_autoloader_new_plugins', $expectedNewPlugins],
             'return' => true,
@@ -203,7 +230,8 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         \WP_Mock::userFunction('add_action', ['return' => true]);
         \WP_Mock::userFunction('add_filter', ['return' => true]);
 
-        $a = new Autoloader;
+        $a = $this->makeAutoloader();
+        $a->boot();
 
         $cache = $this->getProperty($a, 'cache');
         $this->assertArrayNotHasKey('removed-plugin/removed-plugin.php', $cache['plugins']);
@@ -217,7 +245,8 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
             ->with(array_keys(self::$plugins), self::$plugins)
             ->reply('not-an-array');
 
-        $a = new Autoloader;
+        $a = $this->makeAutoloader();
+        $a->boot();
 
         $loaded = $this->getProperty($a, 'loadedPluginEntryPoints');
         $this->assertIsArray($loaded);
@@ -232,7 +261,8 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
             ->with(array_keys(self::$plugins), self::$plugins)
             ->reply(['../../etc/passwd', '20-fake/20-fake.php']);
 
-        $a = new Autoloader;
+        $a = $this->makeAutoloader();
+        $a->boot();
 
         $loaded = $this->getProperty($a, 'loadedPluginEntryPoints');
         $this->assertCount(1, $loaded);
@@ -240,70 +270,57 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         $this->assertNotContains('../../etc/passwd', $loaded);
     }
 
-    /**
-     * Run a callback with WP_PLUGIN_DIR temporarily removed,
-     * exercising the fallback discovery path.
-     */
-    private function withFallbackDiscovery(callable $callback): void
+    public function test_discovery_scans_mu_plugin_dir()
     {
-        $pluginsDir = WP_PLUGIN_DIR;
-        $tempDir = $pluginsDir.'_disabled';
-        rename($pluginsDir, $tempDir);
+        $this->mockPluginData();
 
-        try {
-            \WP_Mock::userFunction('get_plugin_data', [
-                'return' => function ($file) {
-                    $relativePath = basename(dirname($file)).'/'.basename($file);
-                    $map = [
-                        '10-fake/10-fake.php' => ['Name' => 'UwU', 'Version' => '1.0.0'],
-                        '20-fake/20-fake.php' => ['Name' => '0w0', 'Version' => '1.0.0'],
-                    ];
+        $a = $this->makeAutoloader();
 
-                    return $map[$relativePath] ?? ['Name' => ''];
-                },
-            ]);
+        $reflect = new \ReflectionClass(Autoloader::class);
+        $method = $reflect->getMethod('discoverPlugins');
+        $method->setAccessible(true);
+        $plugins = $method->invoke($a);
 
-            $reflect = new \ReflectionClass(Autoloader::class);
-            $a = $reflect->newInstanceWithoutConstructor();
-            $this->setProperty($a, 'relativePath', '/../'.basename(WPMU_PLUGIN_DIR));
+        $this->assertCount(2, $plugins);
+        $this->assertArrayHasKey('10-fake/10-fake.php', $plugins);
+        $this->assertArrayHasKey('20-fake/20-fake.php', $plugins);
 
-            $callback($a, $reflect);
-        } finally {
-            rename($tempDir, $pluginsDir);
-        }
+        $keys = array_keys($plugins);
+        $this->assertEquals('10-fake/10-fake.php', $keys[0]);
+        $this->assertEquals('20-fake/20-fake.php', $keys[1]);
     }
 
-    public function test_fallback_discovery_when_plugins_dir_missing()
+    public function test_discovery_uses_injected_path()
     {
-        $this->withFallbackDiscovery(function (Autoloader $a, \ReflectionClass $reflect) {
-            $method = $reflect->getMethod('discoverPlugins');
-            $method->setAccessible(true);
-            $plugins = $method->invoke($a);
+        $this->mockPluginData();
 
-            $this->assertCount(2, $plugins);
-            $this->assertArrayHasKey('10-fake/10-fake.php', $plugins);
-            $this->assertArrayHasKey('20-fake/20-fake.php', $plugins);
+        $a = $this->makeAutoloader('/nonexistent/empty-dir');
 
-            $keys = array_keys($plugins);
-            $this->assertEquals('10-fake/10-fake.php', $keys[0]);
-            $this->assertEquals('20-fake/20-fake.php', $keys[1]);
-        });
+        $reflect = new \ReflectionClass(Autoloader::class);
+        $method = $reflect->getMethod('discoverPlugins');
+        $method->setAccessible(true);
+        $plugins = $method->invoke($a);
+
+        $this->assertEmpty($plugins);
     }
 
     public function test_count_excludes_non_plugin_directories()
     {
-        $this->withFallbackDiscovery(function (Autoloader $a, \ReflectionClass $reflect) {
-            $discover = $reflect->getMethod('discoverPlugins');
-            $discover->setAccessible(true);
-            $plugins = $discover->invoke($a);
+        $this->mockPluginData();
 
-            $countDirs = $reflect->getMethod('countPluginDirs');
-            $countDirs->setAccessible(true);
-            $count = $countDirs->invoke($a, $plugins);
+        $a = $this->makeAutoloader();
 
-            // fixtures/mu-plugins has 3 subdirs (10-fake, 20-fake, not-a-plugin)
-            // but only 2 are valid plugins — count should be 2
-            $this->assertEquals(2, $count);
-        });
+        $reflect = new \ReflectionClass(Autoloader::class);
+        $discover = $reflect->getMethod('discoverPlugins');
+        $discover->setAccessible(true);
+        $plugins = $discover->invoke($a);
+
+        $countDirs = $reflect->getMethod('countPluginDirs');
+        $countDirs->setAccessible(true);
+        $count = $countDirs->invoke($a, $plugins);
+
+        // fixtures/mu-plugins has 3 subdirs (10-fake, 20-fake, not-a-plugin)
+        // but only 2 are valid plugins — count should be 2
+        $this->assertEquals(2, $count);
     }
 }


### PR DESCRIPTION
## Summary

- Constructor accepts `muPluginDir` and has no side effects — no hook registration or plugin loading
- New `boot()` method registers hooks and loads plugins, is idempotent
- Discovery, loading, and validation use injected path — no direct constant reads
- Removed singleton pattern
- **Breaking:** bootstrap must now call `->boot()` after constructing

Closes #4 and #5

## Upgrade guide

Update `mu-plugins/bedrock-autoloader.php`:

```php
<?php

if (is_blog_installed() && class_exists(\Roots\Bedrock\Autoloader\Autoloader::class)) {
    (new \Roots\Bedrock\Autoloader\Autoloader(WPMU_PLUGIN_DIR))->boot();
}
```

Bedrock will be updated with this change after v2 is tagged.

## Test plan

- [x] Unit tests pass (12 tests, 30 assertions)
- [x] Constructor alone does not register hooks or load plugins
- [x] `boot()` is idempotent
- [x] Discovery uses injected path, not constants
- [x] Tested locally with Radicle — autoloader discovers and loads mu-plugins correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)