### PR TITLE
Fix global variable scope for autoloaded mu-plugins

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -23,7 +23,10 @@ class Autoloader
     /** @var int Number of plugins */
     private $count;
 
-    /** @var array Entrypoints of all loaded plugins */
+    /** @var array Plugins selected for loading after discovery and filtering */
+    private $selectedPluginEntryPoints;
+
+    /** @var array Plugins confirmed as included at file scope */
     private $loadedPluginEntryPoints;
 
     /** @var bool Whether boot() has already run */
@@ -34,37 +37,57 @@ class Autoloader
     ) {}
 
     /**
-     * Register hooks and load plugins. Idempotent.
+     * Discover, filter, and return absolute paths to plugin entrypoints.
+     *
+     * Returns the same list on subsequent calls.
+     *
+     * @return array<string> Absolute paths for inclusion at file scope
      */
-    public function boot(): void
+    public function boot(): array
     {
-        if ($this->booted) {
-            return;
+        if (! $this->booted) {
+            $this->booted = true;
+
+            if (is_admin()) {
+                add_filter('show_advanced_plugins', [$this, 'showInAdmin'], 0, 2);
+            }
+
+            $this->loadPlugins();
         }
 
-        $this->booted = true;
-
-        if (is_admin()) {
-            add_filter('show_advanced_plugins', [$this, 'showInAdmin'], 0, 2);
-        }
-
-        $this->loadPlugins();
+        return array_map(
+            fn ($plugin) => $this->muPluginDir.'/'.$plugin,
+            $this->selectedPluginEntryPoints ?? []
+        );
     }
 
     /**
      * Run some checks then autoload our plugins.
      */
-    public function loadPlugins()
+    private function loadPlugins()
     {
         $this->checkCache();
         $this->validatePlugins();
         $this->countPlugins();
 
         $filtered = apply_filters('bedrock_autoloader_load_plugins', array_keys($this->cache['plugins']), $this->cache['plugins']);
-        $this->loadedPluginEntryPoints = array_values(array_intersect((array) $filtered, array_keys($this->cache['plugins'])));
-        array_map(function ($plugin) {
-            include_once $this->muPluginDir.'/'.$plugin;
-        }, $this->loadedPluginEntryPoints);
+        $this->selectedPluginEntryPoints = array_values(array_intersect((array) $filtered, array_keys($this->cache['plugins'])));
+    }
+
+    /**
+     * Mark plugins as loaded after file-scope includes and register activation hooks.
+     *
+     * Must be called by the bootstrap file after including the plugins returned
+     * by boot(). This ensures activation hooks only fire for plugins whose
+     * files were actually included. Idempotent.
+     */
+    public function markLoaded(): void
+    {
+        if (isset($this->loadedPluginEntryPoints)) {
+            return;
+        }
+
+        $this->loadedPluginEntryPoints = $this->selectedPluginEntryPoints ?? [];
 
         add_action('init', [$this, 'pluginHooks'], 0);
     }
@@ -176,6 +199,10 @@ class Autoloader
      */
     public function pluginHooks()
     {
+        if (! isset($this->loadedPluginEntryPoints)) {
+            return;
+        }
+
         $newPlugins = (array) get_site_option('bedrock_autoloader_new_plugins', []);
         $newPluginsKeys = array_keys($newPlugins);
         foreach ($newPluginsKeys as $plugin_file) {

--- a/tests/unit/AutoloaderTest.php
+++ b/tests/unit/AutoloaderTest.php
@@ -78,6 +78,7 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
 
         $this->assertNull($this->getProperty($a, 'cache'));
         $this->assertNull($this->getProperty($a, 'autoPlugins'));
+        $this->assertNull($this->getProperty($a, 'selectedPluginEntryPoints'));
         $this->assertNull($this->getProperty($a, 'loadedPluginEntryPoints'));
         $this->assertFalse($this->getProperty($a, 'booted'));
     }
@@ -87,15 +88,16 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         $this->mockBaseWpFunctions();
 
         $a = $this->makeAutoloader();
-        $a->boot();
+        $first = $a->boot();
 
         $cacheAfterFirst = $this->getProperty($a, 'cache');
 
-        // Second boot should be a no-op — loadPlugins won't run again
-        $a->boot();
+        // Second boot should return same list without re-running loadPlugins
+        $second = $a->boot();
 
         $cacheAfterSecond = $this->getProperty($a, 'cache');
         $this->assertSame($cacheAfterFirst, $cacheAfterSecond);
+        $this->assertSame($first, $second);
         $this->assertTrue($this->getProperty($a, 'booted'));
     }
 
@@ -110,10 +112,13 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         $this->assertCount(2, $cache['plugins']);
         $this->assertEquals(2, $cache['count']);
 
-        $loaded = $this->getProperty($a, 'loadedPluginEntryPoints');
-        $this->assertCount(2, $loaded);
-        $this->assertContains('10-fake/10-fake.php', $loaded);
-        $this->assertContains('20-fake/20-fake.php', $loaded);
+        $selected = $this->getProperty($a, 'selectedPluginEntryPoints');
+        $this->assertCount(2, $selected);
+        $this->assertContains('10-fake/10-fake.php', $selected);
+        $this->assertContains('20-fake/20-fake.php', $selected);
+
+        // loadedPluginEntryPoints should still be null until markLoaded() is called
+        $this->assertNull($this->getProperty($a, 'loadedPluginEntryPoints'));
     }
 
     public function test_filtered_plugin_does_not_load()
@@ -127,10 +132,10 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         $a = $this->makeAutoloader();
         $a->boot();
 
-        $loaded = $this->getProperty($a, 'loadedPluginEntryPoints');
-        $this->assertCount(1, $loaded);
-        $this->assertContains('20-fake/20-fake.php', $loaded);
-        $this->assertNotContains('10-fake/10-fake.php', $loaded);
+        $selected = $this->getProperty($a, 'selectedPluginEntryPoints');
+        $this->assertCount(1, $selected);
+        $this->assertContains('20-fake/20-fake.php', $selected);
+        $this->assertNotContains('10-fake/10-fake.php', $selected);
     }
 
     public function test_filtered_plugin_activation_is_deferred()
@@ -248,9 +253,9 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         $a = $this->makeAutoloader();
         $a->boot();
 
-        $loaded = $this->getProperty($a, 'loadedPluginEntryPoints');
-        $this->assertIsArray($loaded);
-        $this->assertEmpty($loaded);
+        $selected = $this->getProperty($a, 'selectedPluginEntryPoints');
+        $this->assertIsArray($selected);
+        $this->assertEmpty($selected);
     }
 
     public function test_filter_cannot_inject_arbitrary_paths()
@@ -264,10 +269,10 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         $a = $this->makeAutoloader();
         $a->boot();
 
-        $loaded = $this->getProperty($a, 'loadedPluginEntryPoints');
-        $this->assertCount(1, $loaded);
-        $this->assertContains('20-fake/20-fake.php', $loaded);
-        $this->assertNotContains('../../etc/passwd', $loaded);
+        $selected = $this->getProperty($a, 'selectedPluginEntryPoints');
+        $this->assertCount(1, $selected);
+        $this->assertContains('20-fake/20-fake.php', $selected);
+        $this->assertNotContains('../../etc/passwd', $selected);
     }
 
     public function test_discovery_scans_mu_plugin_dir()
@@ -302,6 +307,93 @@ class AutoloaderTest extends \WP_Mock\Tools\TestCase
         $plugins = $method->invoke($a);
 
         $this->assertEmpty($plugins);
+    }
+
+    public function test_boot_returns_absolute_paths_in_filtered_order()
+    {
+        $this->mockBaseWpFunctions();
+
+        $a = $this->makeAutoloader();
+        $plugins = $a->boot();
+
+        $this->assertCount(2, $plugins);
+        $this->assertEquals(WPMU_PLUGIN_DIR.'/10-fake/10-fake.php', $plugins[0]);
+        $this->assertEquals(WPMU_PLUGIN_DIR.'/20-fake/20-fake.php', $plugins[1]);
+    }
+
+    public function test_boot_respects_filter_order()
+    {
+        $this->mockBaseWpFunctions();
+
+        \WP_Mock::onFilter('bedrock_autoloader_load_plugins')
+            ->with(array_keys(self::$plugins), self::$plugins)
+            ->reply(['20-fake/20-fake.php', '10-fake/10-fake.php']);
+
+        $a = $this->makeAutoloader();
+        $plugins = $a->boot();
+
+        $this->assertCount(2, $plugins);
+        $this->assertEquals(WPMU_PLUGIN_DIR.'/20-fake/20-fake.php', $plugins[0]);
+        $this->assertEquals(WPMU_PLUGIN_DIR.'/10-fake/10-fake.php', $plugins[1]);
+    }
+
+    public function test_activation_hooks_do_not_fire_without_mark_loaded()
+    {
+        $this->mockBaseWpFunctions();
+
+        $a = $this->makeAutoloader();
+        $a->boot();
+
+        // loadedPluginEntryPoints is null — pluginHooks should not fire any activate_ actions
+        $this->assertNull($this->getProperty($a, 'loadedPluginEntryPoints'));
+
+        \WP_Mock::userFunction('get_site_option', [
+            'args' => ['bedrock_autoloader_new_plugins', []],
+            'return' => self::$plugins,
+        ]);
+        \WP_Mock::userFunction('update_site_option', ['return' => true]);
+
+        $activatedPlugins = [];
+        \WP_Mock::userFunction('do_action', [
+            'return' => function () use (&$activatedPlugins) {
+                $activatedPlugins[] = func_get_args()[0];
+            },
+        ]);
+
+        $a->pluginHooks();
+
+        $this->assertEmpty($activatedPlugins);
+    }
+
+    public function test_mark_loaded_enables_activation_hooks()
+    {
+        $this->mockBaseWpFunctions();
+
+        $a = $this->makeAutoloader();
+        $a->boot();
+        $a->markLoaded();
+
+        $this->assertEquals(
+            $this->getProperty($a, 'selectedPluginEntryPoints'),
+            $this->getProperty($a, 'loadedPluginEntryPoints')
+        );
+    }
+
+    public function test_mark_loaded_is_idempotent()
+    {
+        $this->mockBaseWpFunctions();
+
+        $a = $this->makeAutoloader();
+        $a->boot();
+
+        $a->markLoaded();
+        $loadedAfterFirst = $this->getProperty($a, 'loadedPluginEntryPoints');
+
+        // Second call should be a no-op — same state, no duplicate hook registration
+        $a->markLoaded();
+        $loadedAfterSecond = $this->getProperty($a, 'loadedPluginEntryPoints');
+
+        $this->assertSame($loadedAfterFirst, $loadedAfterSecond);
     }
 
     public function test_count_excludes_non_plugin_directories()


### PR DESCRIPTION
## Summary

- Fixes #29 — variables declared in autoloaded mu-plugins are now available in the global scope, matching WordPress core behavior
- `boot()` returns absolute plugin paths for inclusion at file scope instead of including them internally via closure
- Splits plugin state into "selected" (discovered/filtered) and "loaded" (confirmed included) to prevent activation hooks from firing for plugins that were never actually included
- `markLoaded()` must be called after includes to enable activation hooks — both `boot()` and `markLoaded()` are idempotent

## Breaking changes

This is a v2 breaking change. This repo and the Bedrock bootstrap (`bedrock-autoloader.php`) must ship together — the autoloader no longer includes plugin files internally. A companion PR to [roots/bedrock](https://github.com/roots/bedrock) is required.

The bootstrap file must be updated to:

```php
<?php

/**
 * Plugin Name:  Bedrock Autoloader
 * Plugin URI:   https://github.com/roots/bedrock-autoloader
 * Description:  An autoloader that enables standard plugins to be required just like must-use plugins. The autoloaded plugins are included during mu-plugin loading. An asterisk (*) next to the name of the plugin designates the plugins that have been autoloaded.
 * Version:      2.0.0
 * Author:       Roots
 * Author URI:   https://roots.io/
 * License:      MIT License
 */

if (is_blog_installed() && class_exists(\Roots\Bedrock\Autoloader\Autoloader::class)) {
    $autoloader = new \Roots\Bedrock\Autoloader\Autoloader(WPMU_PLUGIN_DIR);

    foreach ($autoloader->boot() as $file) {
        include_once $file;
    }

    $autoloader->markLoaded();

    unset($autoloader, $file);
}
```

## Test plan

- `vendor/bin/phpunit` passes: 17 tests, 43 assertions
- Verified on Trellis VM: a variable declared in an autoloaded mu-plugin is available via `global $var` in theme/plugin code
- Verified on Trellis VM: closure-based include (previous behavior) results in `NULL` for the same variable

Close #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)