### PR TITLE
Add e2e tests for autoloaded mu-plugins

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,63 @@
+FROM php:8.3-fpm
+
+RUN apt-get update && apt-get install -y \
+    mariadb-client \
+    zip \
+    unzip \
+    git \
+    curl \
+    libglib2.0-0 \
+    libnss3 \
+    libnspr4 \
+    libdbus-1-3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libatspi2.0-0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libxkbcommon0 \
+    libasound2 \
+    libcups2 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libgdk-pixbuf-2.0-0 \
+    libgtk-3-0 \
+    libx11-xcb1 \
+    libxcb-dri3-0 \
+    libxss1 \
+    libdrm2 \
+    libxcb1 \
+    libxcb-shm0 \
+    libxext6 \
+    libxrender1 \
+    libxtst6 \
+    fonts-liberation \
+    fonts-dejavu-core \
+    fonts-freefont-ttf \
+    libharfbuzz0b \
+    libcairo-gobject2 \
+    libpangocairo-1.0-0 \
+    libjpeg62-turbo \
+    libpng16-16 \
+    libwebp7 \
+  && docker-php-ext-install -j$(nproc) \
+    mysqli \
+    pdo_mysql \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+  && chmod +x wp-cli.phar \
+  && mv wp-cli.phar /usr/local/bin/wp
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+  && apt-get install -y nodejs \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /roots/autoloader

--- a/.devcontainer/config/nginx.conf
+++ b/.devcontainer/config/nginx.conf
@@ -1,0 +1,15 @@
+server {
+  listen 80;
+  root /roots/bedrock/web;
+  index index.php;
+
+  location / {
+    try_files $uri $uri/ /index.php$is_args$args;
+  }
+
+  location ~ \.php$ {
+    fastcgi_pass app:9000;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    include fastcgi_params;
+  }
+}

--- a/.devcontainer/config/php.ini
+++ b/.devcontainer/config/php.ini
@@ -1,0 +1,7 @@
+memory_limit = 256M
+max_execution_time = 120
+upload_max_filesize = 64M
+post_max_size = 64M
+error_reporting = E_ALL
+display_errors = Off
+log_errors = On

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "Bedrock Autoloader E2E",
+  "dockerComposeFile": ["docker-compose.yml"],
+  "service": "app",
+  "workspaceFolder": "/roots/autoloader",
+  "forwardPorts": [8080]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,48 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/roots/autoloader
+      - bedrock:/roots/bedrock
+    networks:
+      - bedrock
+    depends_on:
+      database:
+        condition: service_healthy
+    environment:
+      WP_CLI_ALLOW_ROOT: 1
+
+  web:
+    image: nginx:alpine
+    ports:
+      - '8080:80'
+    volumes:
+      - bedrock:/roots/bedrock:ro
+      - ./config/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - app
+    networks:
+      - bedrock
+
+  database:
+    image: mariadb:12
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: password
+    networks:
+      - bedrock
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      timeout: 20s
+      retries: 10
+
+volumes:
+  bedrock:
+
+networks:
+  bedrock:
+    driver: bridge

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -81,5 +81,6 @@ wp core install \
   --allow-root
 
 # Install Playwright
+cd /roots/autoloader
 npm install --no-save @playwright/test
 npx playwright install chromium

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /roots
+
+# Create Bedrock project
+composer create-project roots/bedrock bedrock --no-interaction --no-progress --prefer-dist
+
+cd bedrock
+
+# Use the local autoloader source as a path repository
+composer config repositories.autoloader path /roots/autoloader
+composer require roots/bedrock-autoloader:@dev --no-interaction --no-progress
+
+# Add turn-comments-off to the mu-plugins installer path
+php -r '
+    $json = json_decode(file_get_contents("composer.json"), true);
+    $key = "web/app/mu-plugins/{\$name}/";
+    $json["extra"]["installer-paths"][$key][] = "wpackagist-plugin/turn-comments-off";
+    file_put_contents("composer.json", json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+'
+composer require wpackagist-plugin/turn-comments-off --no-interaction --no-progress
+
+# Update the bootstrap for v2 API
+cat > web/app/mu-plugins/bedrock-autoloader.php << 'BOOTSTRAP'
+<?php
+
+/**
+ * Plugin Name:  Bedrock Autoloader
+ * Plugin URI:   https://github.com/roots/bedrock-autoloader
+ * Description:  An autoloader that enables standard plugins to be required just like must-use plugins. The autoloaded plugins are included during mu-plugin loading. An asterisk (*) next to the name of the plugin designates the plugins that have been autoloaded.
+ * Version:      2.0.0
+ * Author:       Roots
+ * Author URI:   https://roots.io/
+ * License:      MIT License
+ */
+
+if (is_blog_installed() && class_exists(\Roots\Bedrock\Autoloader\Autoloader::class)) {
+    $autoloader = new \Roots\Bedrock\Autoloader\Autoloader(WPMU_PLUGIN_DIR);
+
+    foreach ($autoloader->boot() as $file) {
+        include_once $file;
+    }
+
+    $autoloader->markLoaded();
+
+    unset($autoloader, $file);
+}
+BOOTSTRAP
+
+# Create .env
+cat > .env << 'ENV'
+DB_NAME=wordpress
+DB_USER=wordpress
+DB_PASSWORD=password
+DB_HOST=database
+DB_PREFIX=wp_
+
+WP_ENV=development
+WP_HOME=http://web
+WP_SITEURL=${WP_HOME}/wp
+
+AUTH_KEY='generateme'
+SECURE_AUTH_KEY='generateme'
+LOGGED_IN_KEY='generateme'
+NONCE_KEY='generateme'
+AUTH_SALT='generateme'
+SECURE_AUTH_SALT='generateme'
+LOGGED_IN_SALT='generateme'
+NONCE_SALT='generateme'
+ENV
+
+# Install WordPress
+wp core install \
+  --url=http://web \
+  --title=Bedrock \
+  --admin_user=admin \
+  --admin_password=admin \
+  --admin_email=admin@example.com \
+  --skip-email \
+  --allow-root
+
+# Install Playwright
+npm install --no-save @playwright/test
+npx playwright install chromium

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,12 @@
 * text=auto eol=lf
 
 /tests export-ignore
+/.devcontainer export-ignore
 /.github export-ignore
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /phpunit.xml export-ignore
+/playwright.config.cjs export-ignore
 /pint.json export-ignore
 /README.md export-ignore

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,17 @@
+name: Integration
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Start dev container and test
+        uses: devcontainers/ci@v0.3
+        with:
+          configFile: .devcontainer/devcontainer.json
+          runCmd: |
+            .devcontainer/setup.sh
+            WP_HOME=http://web npx playwright test --config=playwright.config.cjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 composer.lock
 /vendor
+/node_modules
+/test-results
 .phpunit.result.cache

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,0 +1,9 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30000,
+  use: {
+    baseURL: process.env.WP_HOME || 'http://localhost:8080',
+  },
+});

--- a/tests/e2e/mu-plugins.spec.cjs
+++ b/tests/e2e/mu-plugins.spec.cjs
@@ -1,0 +1,21 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Bedrock Autoloader', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/wp/wp-login.php');
+    await page.fill('#user_login', 'admin');
+    await page.fill('#user_pass', 'admin');
+    await page.click('#wp-submit');
+    await page.waitForURL('**/wp-admin/**');
+  });
+
+  test('autoloaded mu-plugin appears on must-use plugins page with asterisk', async ({ page }) => {
+    await page.goto('/wp/wp-admin/plugins.php?plugin_status=mustuse');
+
+    const pluginRow = page.locator('table.plugins tr', {
+      has: page.locator('text=Turn Comments Off *'),
+    });
+
+    await expect(pluginRow).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds devcontainer setup that creates a fresh Bedrock project with the local autoloader symlinked via path repository
- Installs `turn-comments-off` as a subdirectory mu-plugin to test autoloading
- Playwright test logs into wp-admin and verifies the autoloaded plugin appears on the must-use plugins page with the `*` suffix
- CI workflow runs the full setup + e2e test via `devcontainers/ci`

Close #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)